### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: dezodemius/recipeapp
@@ -82,6 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_app, run_tests, generate_version]
     if: success()
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Dezodemius/RecipeApp/security/code-scanning/5](https://github.com/Dezodemius/RecipeApp/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for all jobs. Additionally, we will override the permissions for specific jobs (e.g., `release_docker_and_create_tag`) that require additional access. This ensures that each job has only the permissions it needs.

1. Add a root-level `permissions` block with `contents: read` as the default, which is sufficient for most jobs.
2. For the `release_docker_and_create_tag` job, explicitly grant additional permissions (`contents: write`, `packages: write`, and `pull-requests: write`) to allow it to push Docker images, create git tags, and publish releases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
